### PR TITLE
Update `lodash-es` version

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    babel: {
+      includePolyfill: true
+    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
-    "lodash-es": "^3.10.0"
+    "lodash-es": "~4.6.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/utils/lodash-exports-test.js
+++ b/tests/unit/utils/lodash-exports-test.js
@@ -16,5 +16,5 @@ test('lodash individual modules have been exported', function(assert) {
 
   assert.ok(_string, 'lodash string is exported alone');
   assert.equal(typeof _string.trim, 'function', 'lodash string#trim() exists');
-  assert.equal(typeof _string.trunc, 'function', 'lodash string#trunc() exists');
+  assert.equal(typeof _string.truncate, 'function', 'lodash string#truncate() exists');
 });


### PR DESCRIPTION
Update `lodash-es` version to `~4.6.1`.
Change `_.trunc` to `_.truncate` in tests.

**Note:**
This PR is copy of [#22](https://github.com/levanto-financial/ember-lodash/pull/22), but not outdated and fixing version of `lodash-es`.

